### PR TITLE
Check in a Makefile that includes automatic provisioning of the venv.

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,9 @@
+root = true
+
+[*]
+end_of_line = lf
+insert_final_newline = true
+
+[Makefile]
+indent_style = tab
+indent_size = 8

--- a/.gitignore
+++ b/.gitignore
@@ -148,7 +148,6 @@ styles/
 
 # Ignore build dir in Sphinx + more
 .venv/
-Makefile
 build/
 docs/build
 index.deprecated

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,27 @@
+SPHINXBUILD   = ./.venv/bin/sphinx-build
+SPHINXOPTS    =
+SOURCEDIR     = docs
+BUILDDIR      = build
+
+# Put it first so that "make" without argument is like "make help".
+.PHONY: help
+help: dependencies
+	@$(SPHINXBUILD) -M help "$(SOURCEDIR)" "$(BUILDDIR)" $(SPHINXOPTS) $(O)
+
+./.venv/pyvenv.cfg:
+	@echo "provisioning environment"
+	@/usr/bin/env python3 -m venv ./.venv
+
+.PHONY: dependencies
+dependencies: ./.venv/pyvenv.cfg ./requirements.txt
+	@echo "installing dependencies"
+	@./.venv/bin/pip3 install -r ./requirements.txt
+
+./requirements.txt:
+	@
+
+# Catch-all target: route all unknown targets to Sphinx using the new
+# "make mode" option.  $(O) is meant as a shortcut for $(SPHINXOPTS).
+.PHONY: Makefile
+%: Makefile
+	@$(SPHINXBUILD) -M $@ "$(SOURCEDIR)" "$(BUILDDIR)" $(SPHINXOPTS) $(O)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
+setuptools
 sphinx==7.2.3
 sphinx_rtd_theme==1.3.0
 sphinxemoji==0.2.0


### PR DESCRIPTION
There was already a Makefile in local be folks locally - extend this with tricks to create the virtual env and install any requisite dependencies within it. The added targets should also notice future dependency changes.

While here also add setuptools as an explicit dependency in order to allow operation on Pyhton 3.12+ where it is no longer an included battery.