### PR TITLE
Swap use of an unknown ::info directive to ::note.

### DIFF
--- a/docs/sections/erda/homepage/index.rst
+++ b/docs/sections/erda/homepage/index.rst
@@ -91,7 +91,7 @@ The **Cloud** button leads to the page of the cloud nodes provided by Multi-purp
 
 Instances are not time limited and can be resumed from any client. The spawned instances are persistent, meaning that any change made during a session is preserved even if the server is terminated.
 
-.. info::
+.. note::
    Our Cloud services are currently in beta testing and access is only granted for a limited set of users who are already experienced with remote Linux system management over SSH. If you fit in that category and would like to join the testing, please get in touch.
 
 


### PR DESCRIPTION
The intention here appears to be that that the beta testing comment appears as a note to the above content - use the note directive instead.

The following represents how it enders after this change:
![migrid-user-docs use-note-directive](https://github.com/user-attachments/assets/af496e66-6271-45f3-afc0-0294a42fa0b5)
