### PR TITLE
Implement a barebones CI for setup for the user docs.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,20 @@
+name: User Docs
+
+on:
+  push
+
+jobs:
+  test-build:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v4
+    - name: Set up latest stable Python 3.x
+      uses: actions/setup-python@v5
+      with:
+        python-version: "3.x"
+    - name: Install dependencies
+      run: |
+        make dependencies
+    - name: Ensure the docs build
+      run: |
+        make test-build

--- a/Makefile
+++ b/Makefile
@@ -20,6 +20,10 @@ dependencies: ./.venv/pyvenv.cfg ./requirements.txt
 ./requirements.txt:
 	@
 
+.PHONY: test-build
+test-build: dependencies
+	@$(SPHINXBUILD) -W "$(SOURCEDIR)" "$(BUILDDIR)" $(SPHINXOPTS)
+
 # Catch-all target: route all unknown targets to Sphinx using the new
 # "make mode" option.  $(O) is meant as a shortcut for $(SPHINXOPTS).
 .PHONY: Makefile


### PR DESCRIPTION
Add a "build-test" Makefile target which executes a sphinx docs build with warnings turned into errors. Use this new target within a GitHub workflow such that the ability to build the docs is verified on each commit.